### PR TITLE
Add English README

### DIFF
--- a/README-cn.md
+++ b/README-cn.md
@@ -1,0 +1,319 @@
+# Miment
+
+
+## 介绍
+Miment ("Mini Moment") 是一个轻量级的时间库，打包压缩后体积 1K，没有过多的方法。它的上手成本几乎为零，无需反复查阅文档。当你只需要 Moment 的若干核心能力但又不希望使你的包体积膨胀时，欢迎尝试 Miment。
+
+>  首先致敬一下 Moment，非常好用的一个时间库。我本身也是 Moment 重度使用者，用习惯了 Moment，一碰到需要处理时间的需求立马 Moment。不过有时候想想，Moment 给我们提供了那么多的功能，但是我们天天用的， 也就那么一两个。刚好最近在写微信小程序，然后在页面引入 Moment，打包完，包竟然大了 200 多 K，把 Moment 去掉，就直接少掉 200 多 K。反复试了好几次，确定一个 Moment 在小程序里面，占用大概 200K 的空间。于是就想自己写一个类似 Moment 的精简的时间库，于是就有了这个。为什么要叫Miment 呢？其实刚开始我是想叫 Mini-Moment 的，但是考虑到以后可能会经常使用到，打 2 个单词中间还要加一个横杆太累了，所以就把 Mini-Moment 缩水成 Miment 了。
+
+[查看示例](https://noahlam.github.io/Miment)
+
+## 安装
+对浏览器环境，在页面引入 `./dist/miment-min.js` 即可：
+
+``` html
+<script src="//unpkg.com/miment/dist/miment-min.js"></script>
+<script>miment().format()</script>
+```
+
+在 NPM 生态中使用时，请使用包管理器安装 Miment：
+
+```
+npm i miment
+```
+
+然后就可在你的项目中使用了：
+
+``` js
+import miment from 'miment'
+miment().format() // 2018-04-09 23:01:58
+```
+
+## API
+
+API 方法可分为三类：
+
+* 返回 Computed 结果的方法。如 `format` 返回字符串，`json` 返回的是一个 JSON 对象。
+* 返回 `Miment` 对象的方法，即支持链式调用。
+* 从 Date 对象继承的方法。Date 对象上的方法 miment 也可以使用，这些方法类似私有 API，不推荐直接使用。
+
+
+### 返回 Computed 结果的方法
+
+#### `format`
+format 方法几乎是我们平时最常用的了。它一共接收 2 个参数，这 2 个参数都有默认值，不传则使用默认值：
+
+<table>
+  <tr>
+    <td>参数名称</td>
+    <td>参数类型</td>
+    <td>参数默认值</td>
+    <td>是否必传</td>
+    <td>说明</td>
+  </tr>
+  <tr>
+    <td>格式化的字符串</td>
+    <td>string</td>
+    <td>'YYYY-MM-DD hh:mm:ss'</td>
+    <td>N</td>
+    <td>
+      年 YYYY<br>
+      月 MM<br>
+      日 DD<br>
+      时 hh<br>
+      分 mm<br>
+      秒 ss<br>
+      毫秒 SSS<br>
+      数字星期 ww<br>
+      中文星期 WW
+    </td>
+  </tr>
+  <tr>
+    <td>是否为时间差</td>
+    <td>boolean</td>
+    <td>false</td>
+    <td>N</td>
+    <td>格式化 distance 时间差时，使用 true</td>
+  </tr>
+</table>
+
+* 本着简单的原则，我们没有实现特别灵活的格式化方式。有时灵活也意味着学习成本：你需要记忆更多的用法，不是吗？
+* 格式化字符串**区分大小写**，记忆技巧是日期大写如 `YYYY MM DD`，时间小写如 `hh mm ss`，毫秒跟星期特殊的单独记。参数格式需严格匹配，长度过多或过少均无效，如 `YYYY` 写成 `YYY` 或 `YY` 均无效。
+* 对第二个参数的使用，参见 `distance` 方法。
+
+``` js
+miment().format('YYYY年MM月DD日 hh:mm:ss')
+// 2018-04-09 23:49:36
+
+miment().format('YYYY/MM/DD hh-mm-ss SSS')
+// 2018/04/09 23-49-36 568
+
+miment().format('YYYY年MM月DD日 星期WW')
+// 2018年04月09日 星期一
+
+miment().format('YYYY年MM月DD日 星期ww')
+// 2018年04月09日 星期1 *周日对应星期0*
+```
+
+作为扩展，如果我们只想获取单独的年、月或日，可这样使用：
+
+``` js
+miment().format('YYYY') // 2018
+miment().format('MM') // 04
+miment().format('DD') // 09
+miment().format('hh') // 23
+miment().format('mm') // 57
+miment().format('ss') // 16
+miment().format('SSS') // 063
+miment().format('ww') // 1
+miment().format('WW') // 一
+```
+
+基于这个方法，你可以不需要记忆大部分原生的日期方法（如 `getFullYear` / `getDate` / `getDay` 等），使用统一的 `format` 处理各种需求。
+
+#### `json`
+输出 JSON 格式的时间字段：
+
+``` js
+miment().json()
+```
+
+``` json
+{
+  "year": 2018,
+  "month": 4,
+  "date": 11,
+  "hour": 8,
+  "minute": 57,
+  "second": 41,
+  "day": 3,
+  "milliSecond": 87
+}
+```
+
+#### `stamp`
+输出时间戳，不需参数。
+
+``` js
+miment().stamp()
+// 1523408529932
+```
+
+#### `daysInMonth`
+获取当前 `Miment` 对象所在月的天数。
+
+``` js
+miment().daysInMonth()
+// 30
+```
+
+### 支持链式调用的方法
+
+#### `add`
+增加或减少时间。它接收 2 个参数：
+
+<table style='border-collapse:collapse;'>
+  <tr>
+    <td>参数名称</td>
+    <td>参数类型</td>
+    <td>参数默认值</td>
+    <td>是否必传</td>
+    <td>说明</td>
+  </tr>
+  <tr>
+    <td>增量</td>
+    <td>number</td>
+    <td>0</td>
+    <td>N</td>
+    <td>要增加的时间量，增加传正数，减少传负数</td>
+  </tr>
+  <tr>
+    <td>单位</td>
+    <td>string</td>
+    <td>无默认值</td>
+    <td>Y</td>
+    <td>
+      要增加的时间单位<br>
+      可选同 format 格式化字符串</td>
+  </tr>
+</table>
+
+为方便使用，**单位**的可选参数格式与格式化方法 `format` 的保持一致。同样严格匹配大小写与长度。
+
+``` js
+miment().add(1,'DD') // 增加一天
+miment().add(1, 'YYYY').add(2, 'MM').add(-3, 'DD') // 增加 1 年 2 个月又减回 3 天
+miment().add(-1,'ww') // 减去一周，即获取上周的日期
+miment().add(500,SSS) // 增加 500 毫秒
+```
+
+`add` 返回的值是增加完后的 `Miment` 对象，我们可以在它后面继续调用 mimont 支持的方法:
+
+``` js
+miment().add(1,'DD').format()
+// 2018-04-12 09:29:55
+```
+
+需要注意的是，当你调完返回 Computed 结果的方法后，返回的对象类型不是 `Miment`，故而不支持链式调用：
+
+```
+miment().add(1,'DD').format().add(1,'DD') // 报错
+```
+
+#### `distance`
+计算 2 个时间的距离。它接收 2 个参数，返回一个 `Miment` 对象：
+
+<table style='border-collapse:collapse;'>
+  <tr>
+    <td>参数名称</td>
+    <td>参数类型</td>
+    <td>参数默认值</td>
+    <td>是否必传</td>
+    <td>说明</td>
+  </tr>
+  <tr>
+    <td>起始时间</td>
+    <td>miment/date/number/string</td>
+    <td>无</td>
+    <td>Y</td>
+    <td>接受4种类型参数，会自动转换</td>
+  </tr>
+  <tr>
+    <td>结束时间</td>
+    <td>miment/date/number/string</td>
+    <td>无</td>
+    <td>N</td>
+    <td>同上</td>
+  </tr>
+</table>
+
+* 只传一个起始时间时，返回 **起始时间 - miment当前时间**
+* 提供起始时间和结束时间时，返回 **起始时间 - 结束时间**。相减顺序如何？先出现的减去后出现的：
+
+``` js
+miment().distance('2018-04-10 00:00:00')
+// Mon Dec 29 1969 22:11:51 GMT+0800 (CST)
+
+miment().distance(1523408529932)
+// Wed Dec 31 1969 07:13:47 GMT+0800 (CST)
+```
+
+``` js
+miment().distance('2018-04-10 00:00:00')
+// Mon Dec 29 1969 22:11:51 GMT+0800 (CST)
+
+miment().distance(1523408529932)
+// Wed Dec 31 1969 07:13:47 GMT+0800 (CST)
+
+miment().distance('2018-04-10 00:00:00', new Date())
+// Mon Dec 29 1969 22:11:13 GMT+0800 (CST)
+
+miment().distance('2018-04-10 00:00:00', '2018-04-11 00:00:00')
+// Mon Dec 29 1969 22:10:46 GMT+0800 (CST)
+```
+
+你一定注意到了，为什么 `distance` 方法返回的年份是 1969 年呢？这实际上是基于`1970-01-01 00:00:00` 的毫秒数，参见 [Unix 时间](https://en.wikipedia.org/wiki/Unix_time)，而我们把两个时间相减，得到的可能是一个相对很小的时间戳（还可能是负数)，所以离 1970 很近。
+
+那我们要怎么显示我们能看得懂的时间呢？配合 `format` 即可。`format` 的第二个参数是用于用来格式化 `distance` 计算出的时间差，只要把第二个参数设为 `true`，即可将当前时间格式化成时间差。作为对比：
+
+``` js
+miment().distance(1523408529932).format('YYYY年MM月DD日 hh时mm分ss秒')
+// 1969年12月30日 00时52分16秒
+
+miment().distance(1523408529932).format('YYYY年MM月DD日 hh时mm分ss秒', false)
+// 1969年12月30日 00时52分16秒
+```
+
+把第二个参数设为 `true`：
+
+``` js
+miment().distance(1523408529932).format('YYYY年MM月DD日 hh时mm分ss秒', true)
+// 00年01月03日 23时08分23秒
+```
+
+#### `firstDayOfWeek`
+获取本周的第一天（周日），无参数：
+
+``` js
+miment().firstDayOfWeek() // Sun Apr 08 2018 11:27:55 GMT+0800 (CST)
+miment().firstDayOfWeek().format() // 2018-04-08 11:27:55
+```
+
+如果想获取周一呢？周二、三、四、五、六呢？
+
+``` js
+miment().firstDayOfWeek().add(1,'DD').format()
+// 2018-04-09 11:27:55
+```
+
+#### `firstDay`
+获取每个月的第一天，无参数：
+
+``` js
+miment().firstDay() // Sun Apr 01 2018 00:00:00 GMT+0800 (CST)
+miment().firstDay().format() // 2018-04-01 00:00:00
+```
+
+#### `lastDay`
+获取每个月的最后一天，无参数：
+
+``` js
+miment().lastDay()
+// Mon Apr 30 2018 00:00:00 GMT+0800 (CST)
+
+miment().lastDay().format()
+// 2018-04-30 00:00:00
+```
+
+### Date 自有方法
+
+`Miment` 继承自 Date 对象，所以也拥有 Date 对象的所有方法。请移步至 [MDN 查看](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date)。
+
+需要注意的是，由于继承而来的方法是属于 Date 对象的，为保持一致，我们没有对方法做改动。故而方法无法返回 miment 对象，也无法链式调用 miment。
+
+
+## 许可
+MIT
+
+## 写在最后
+目前这些功能（函数），是我们团队在日常实践中碰到的比较常用的。如果你对功能有新的需求或者建议，欢迎给我们提 [Issue](https://github.com/noahlam/Miment/issues)。如果喜欢miment，请在我的 [GitHub](https://github.com/noahlam/Miment) 上给我一个 star，你的 star 就是我最大的动力了，谢谢！

--- a/README.md
+++ b/README.md
@@ -1,270 +1,235 @@
-### 介绍
+# Miment
 
-Miment 是一个轻量级的时间库（打包压缩后只有1K）,没有太多的方法，
-Miment的设计理念就是让你以几乎为零的成本快速上手，无需一遍一遍的撸文档
+Miment is an aero-weigh time library (1KB minified) but get things done efficiently.
 
-### 由来 
+* [中文 README](./README-cn.md)
+* [Example](https://noahlam.github.io/Miment/)
 
-首先 致敬一下Moment，非常好用的一个时间库，我本身也是Moment重度使用者，用习惯了Moment,
-一碰到需要处理时间的需求，立马Moment,不过有时候想想，Moment给我们提供了那么多的功能，但是我们天天用的，
-也就那么一两个，刚好最近在写微信小程序，然后在页面引入Moment，打包完，包竟然大了200多K，把Moment去掉，
-就直接少掉200多K,反复试了好几次，确定一个Moment在小程序里面，占用大概200K的空间，于是就想自己写一个类似
-Moment的精简的时间库，于是就有了这个，为什么要叫Miment呢，其实刚开始我是想叫Mini-Moment的，
-但是考虑到以后可能会经常使用到，打2个单词中间还要加一个横杆太累了，所以就把Mini-Moment缩水成Miment了。
+### Why
 
-### 开始使用
+Moment is an **extraordinary** time library that almost covers everything you need, with a massive (200KB+) size. Suppose 90% of its daily usage can be fulfilled within 1% codebase, this tradeoff can be worthwhile. So there comes miment as "mini-moment".
 
-如果你是直接在浏览器里面使用，请下载`./dist/miment-min.js`到你的项目里面去，然后在页面引入后即可直接使用miment
-    
-    <script src='你js存放的目录/miment-min.js'> </script>
-    <script>
-        miment().format()  //  2018-04-09 23:01:58 这是我写这篇文档的时候，运行代码显示的时间
-    </script>
 
-如果你是在单页面应用或者nodejs环境下使用,首先你需要使用安装一下Miment
+## Install
+For NPM environment:
 
-    npm i miment
-   
-或者
+```
+npm intsall miment
+```
 
-    yarn add miment
+Import into codebase and go:
 
-然后就可以在你的项目中使用了
+``` js
+import miment from 'miment'
+miment().format() // 2018-04-09 23:01:58
+```
 
-    import miment from 'miment'
-    miment().format()
+For browser usage, simply include `./dist/miment-min.js`:
 
-### API 
+``` html
+<script src="//unpkg.com/miment/dist/miment-min.js"></script>
+<script>miment().format()</script>
+```
 
-> 你也可以猛戳这里看[example](https://noahlam.github.io/Miment/)
 
-**API 分为3大类**
+## Walkthrough
+* [Format Time](#format-time)
+* [Calculate Time](#calculate-time)
 
-第一类是返回其他对象的，比如format返回的是字符串;  json返回的是一个josn
+### Format Time
+For most daily usage, `format` is what you need:
 
-第二类是返回miment对象的，你可以在调完一个api后面继续调用另一个api,也就是我们所说的链式调用  
+``` js
+miment().format('YYYY年MM月DD日 hh:mm:ss') // 2018-04-09 23:49:36
+miment().format('YYYY/MM/DD hh-mm-ss SSS') // 2018/04/09 23-49-36 568
+miment().format('YYYY年MM月DD日 星期WW') // 2018年04月09日 星期一
+miment().format('YYYY年MM月DD日 星期ww') // 2018年04月09日 星期1 *周日对应星期0*
+```
 
-第三类是从Date对象继承的，也就是说Date对象有的方法，miment也同样有，该类方法建议尽量少用
+What if you only what to get a date field?
 
-#### 第一类
+``` js
+miment().format('YYYY') // '2018'
+miment().format('MM') // '04'
+miment().format('DD') // '09'
+// ...
+```
 
-1. `format` **格式化时间** ,format方法也就是我们平时最常用的一个了，它一共接收2个参数，这2个参数都有默认值，不传就使用默认值
+For JSON format, `miment().json()` yields:
 
-    <table>
-    	<tr>
-        	<td>参数名称</td>
-            <td>参数类型</td>
-            <td>参数默认值</td>
-            <td>是否必传</td>
-            <td>说明</td>
-        </tr>
-        <tr>
-        	<td>格式化的字符串</td>
-            <td>string</td>
-            <td>'YYYY-MM-DD hh:mm:ss'</td>
-            <td>N</td>
-            <td>年YYYY,月MM,日DD,时hh,分mm,秒ss,毫秒SSS,数字星期ww,中文星期WW</td>
-        </tr>
-        <tr>
-        	<td>是否是格式化一个时间差</td>
-            <td>boolean</td>
-            <td>false</td>
-            <td>N</td>
-            <td>比如你要计算的时间是一个倒计时，这个时候也就需要传true</td>
-        </tr>
-    </table>
+``` json
+{
+  "year": 2018,
+  "month": 4,
+  "date": 11,
+  "hour": 8,
+  "minute": 57,
+  "second": 41,
+  "day": 3,
+  "milliSecond": 87
+}
+```
 
-    > 本着简单的原则，这里格式化方式没有做的太灵活,有时候灵活也是一种学习成本，因为你需要记很多的用法，不是吗？,
-    **注意**格式化字符串区分大小写，记的技巧是日期大写 YYYY MM DD，时间小写 hh mm ss 毫秒跟星期特殊的单独记，
-    参数必须严格按照说明里面的填写，多一个或者少一个都认不到，比如YYYY写成YYY或者YY这样是识别不了的
+For other output formats, you can have `miment().stamp()` for timestamp, and `miment().daysInMonth()` for days count in corresponding month.
 
-    > 第二个参数的用法可以参考 distance函数
+### Calculate Time
+What's the date 10 days after? `add` is what you need:
 
-    示例
+``` js
+miment().add(1,'DD') // next day
+miment().add(1,'YYYY').add(2,'MM').add(-3,'DD') // chaining
+miment().add(-1,'ww') // date last week
+miment().add(500,SSS) // add 500ms
+```
 
-        miment().format('YYYY年MM月DD日 hh:mm:ss')  // 2018-04-09 23:49:36
-        miment().format('YYYY/MM/DD hh-mm-ss SSS') // 2018/04/09 23-49-36 568
-        miment().format('YYYY年MM月DD日 星期WW')     // 2018年04月09日 星期一
-        miment().format('YYYY年MM月DD日 星期ww')     // 2018年04月09日 星期1 (星期日这边会显示星期0)
+> Remember not to chain `add()` after `format()`, since `format()` returns string instead of miment instance:
+> 
+> ``` js
+> miment().add(1, 'DD').format().add(1, 'DD') // Error!
+> ```
 
-    扩展一下，如果我们只是想获取年份或者月份或者日，可以这样用
+How to count distance between 2 dates? You have `distance`:
 
-        miment().format('YYYY')   // 2018
-        miment().format('MM')     // 04
-        miment().format('DD')     // 09
-        miment().format('hh')     // 23
-        miment().format('mm')     // 57
-        miment().format('ss')     // 16
-        miment().format('SSS')    // 063
-        miment().format('ww')     // 1
-        miment().format('WW')     // 一
+``` js
+miment().distance('2018-04-11 00:00:00')
+// Thu Jan 08 1970 21:04:50 GMT+0800 (CST)
+```
 
-    所以，有了这个方法，其实你可以不需要去记大部分原生的方法（getFUllYear,getDate,getDay...）,所有的需求一个format搞定，
-    这就是我们追求的极简，当然，也会有一丢丢的性能损失，不过个人觉得对于当今的硬件设备，你完全可以忽略这一点点性能。除非你的项目很特殊。
+By default the instance returned by `distance` is resolved as unix timestamp relative to 1970 "epoch". In this case, use second argument for `format` API on formatting:
 
-2. `json` **输出json格式的时间**,不需要参数
-
-    直接上代码
-
-        miment().json()
-
-    看输出
-
-        {
-            "year": 2018,
-            "month": 4,
-            "date": 11,
-            "hour": 8,
-            "minute": 57,
-            "second": 41,
-            "day": 3,
-            "milliSecond": 87
-        }
+``` js
+miment().distance(1523408529932).format('YYYY/MM/DD')
+// wrong: '1970/01/08'
 
-    输出内容比较简单，应该很好理解，这里就不对输出做介绍了，day返回的是星期几，从0-星期天 1-星期一，以此类推
+miment().distance('2018-04-11 00:00:00').format('YYYY/MM/DD', true)
+// correct: '0/00/07'
+```
 
-3. `stamp` **输出时间戳**,不需要参数
+For other common calculation, see [reference](#reference).
 
-        miment().stamp()
 
-    看输出
+## Reference
 
-        1523408529932
 
-    会输出一串代表当前时间的数字，这个对前端基本没啥用，不过有时候后端的同学会要求传这个
+### Factory
 
-4. `daysInMonth` **获取当前月的天数**,不需要参数
+#### `miment`
+`miment(string?|Date?) => Miment`
 
-          miment().daysInMonth()   // 30
+For miment instance methods, there are basically 3 kinds of methods available:
 
-#### 第二类
+* Chainable methods **returning `Miment` instance**, e.g., `add` and `distance`.
+* Unchainable methods **returning computed values**, e.g., `format` and `json`.
+* Methods inherited from native `Date` model.
 
-5. `add` **增加或减少时间**,它接收2个参数
+### Chainable
 
-    <table style='border-collapse:collapse;' >
-    	<tr>
-        	<td>参数名称</td>
-            <td>参数类型</td>
-            <td>参数默认值</td>
-            <td>是否必传</td>
-            <td>说明</td>
-        </tr>
-    	<tr>
-        	<td>增量</td>
-            <td>number</td>
-            <td>0</td>
-            <td>N</td>
-            <td>要增加的时间量，增加传正数，减少传负数</td>
-        </tr>
-    	<tr>
-        	<td>增量单位</td>
-            <td>string</td>
-            <td>无默认值</td>
-            <td>Y</td>
-            <td>要增加的时间单位<br>可选有YYYY MM DD hh mm ss SSS ww WW</td>
-        </tr>
-    </table>
+#### `add`
+`add(amount: number, unit: string) => Miment`
 
-    > 单位 的可选参数跟格式化方法`format`的类似，这么做也是为了方便记忆，只需要记一套方案
+Get `Miment` object with offset date added.
 
-    > **同样地** 单位也区分大小写，记的技巧是日期大写 YYYY MM DD，时间小写 hh mm ss 毫秒跟星期特殊的单独记
-    参数必须严格按照说明里面的填写，多一个或者少一个都认不到，比如YYYY写成YYY或者YY这样是识别不了的
+``` js
+miment().add(1,'DD')
+miment().add(1,'YYYY').add(2,'MM').add(-3,'DD')
+miment().add(-1,'ww')
+miment().add(500,SSS)
+```
 
-        miment().add(1,'DD')  // 增加一天
-        miment().add(1,'YYYY').add(2,'MM').add(-3,'DD')  // 增加1年2个月又减回去3天
-        miment().add(-1,'ww')  // 减去一周 --即获取上周的日期
-        miment().add(500,SSS)  // 增加500毫秒
+#### `distance`
+`distance(dt: Miment|Date|string, dt2: Miment?|Date?|string?) => Miment`
 
-    add返回的值是增加完后的miment对象，所以我们可以在它后面继续调用miment有的方法。
+Get `Miment` object measuring distance between two dates. If only one argument is provided, it returns distance between that time and current time.
 
-        miment().add(1,'DD').format()   // 我测试的时候，打印的是 2018-04-12 09:29:55
+To get the formatted result, please `format` it with the second `true` flag.
 
-    需要注意的是，当你调完`第一类`的方法以后，返回的就不是miment对象了，比如`format`返回的是一个字符串，这个时候你就不能再调用miment上的方法了，
-    会报错 `Uncaught TypeError: miment(...).format(...).xxx is not a function`  因为字符串的原型上面没有这个方法
+``` js
+miment().distance('2018-04-10 00:00:00')
+// Mon Dec 29 1969 22:11:51 GMT+0800 (CST)
 
-        miment().add(1,'DD').format().add(1,'DD')  // 报错
+miment().distance(1523408529932)
+// Wed Dec 31 1969 07:13:47 GMT+0800 (CST)
 
-6. `distance` **计算2个时间的距离** 接收2个参数，返回一个miment对象
+miment().distance('2018-04-10 00:00:00', new Date())
+// Mon Dec 29 1969 22:11:13 GMT+0800 (CST)
 
-     <table style='border-collapse:collapse;' >
-        	<tr>
-            	<td>参数名称</td>
-                <td>参数类型</td>
-                <td>参数默认值</td>
-                <td>是否必传</td>
-                <td>说明</td>
-            </tr>
-        	<tr>
-            	<td>起始时间</td>
-                <td>miment/date/number/string</td>
-                <td>无</td>
-                <td>Y</td>
-                <td>接受4种类型参数，会自动转换</td>
-            </tr>
-        	<tr>
-            	<td>结束时间</td>
-                <td>miment/date/number/string</td>
-                <td>无</td>
-                <td>N</td>
-                <td>同上</td>
-            </tr>
-        </table>
+miment().distance('2018-04-10 00:00:00', '2018-04-11 00:00:00')
+// Mon Dec 29 1969 22:10:46 GMT+0800 (CST)
+```
 
-    > 只传一个起始时间的时候，返回 **起始时间 - miment当前时间**
+#### `firstDayOfWeek`
+`firstDayOfWeek() => Miment`
 
-    > 起始时间和结束时间都有传的时候，返回 **起始时间 - 结束时间**
+Get `Miment` object representing first day (Sunday) of the week. For other weekday, simply chaining it with `add`.
 
-    > 到底是谁减谁? 这么记--先出现的减去后出现的
+``` js
+miment().firstDayOfWeek()
+// Sun Apr 08 2018 11:27:55 GMT+0800 (CST)
 
-        miment().distance('2018-04-10 00:00:00')  // Mon Dec 29 1969 22:11:51 GMT+0800 (CST)
-        miment().distance(1523408529932)          // Wed Dec 31 1969 07:13:47 GMT+0800 (CST)
+miment().firstDayOfWeek().format()
+// 2018-04-08 11:27:55
+```
 
-        miment().distance('2018-04-10 00:00:00', new Date())  //Mon Dec 29 1969 22:11:13 GMT+0800 (CST)
-        miment().distance('2018-04-10 00:00:00', '2018-04-11 00:00:00')  //Mon Dec 29 1969 22:10:46 GMT+0800 (CST)
+#### `firstDay`
+`firstDay() => Miment`
 
-    你一定注意到了，distance方法返回的时间，竟然都是1969年的？ 这实际上是基于1970-01-01 00:00:00的一个毫秒数，
-    具体请看 [百度百科-unix时间](https://baike.baidu.com/item/UNIX%E6%97%B6%E9%97%B4/8932323),
-    而我们把两个时间相减，得到的可能是一个相对来说很小的数(还有可能是负数)，所以离1970很近
+Get `Miment` object representing first day of the month.
 
-    那我们要怎么显示我们能看得懂的时间呢？ 很简单 用格式化时间函数format,还记得format函数的第二个参数吗？
-    就是专门用来格式化distance计算出来的时间差，只要把第二个参数设为true,就能把当前时间格式化成时间差
-    我们先来看看第二个参数不传，或者传false的时候是什么样子的
+``` js
+miment().firstDay()
+// Sun Apr 01 2018 00:00:00 GMT+0800 (CST)
 
-        miment().distance(1523408529932).format('YYYY年MM月DD日 hh时mm分ss秒')        // 1969年12月30日 00时52分16秒
-        miment().distance(1523408529932).format('YYYY年MM月DD日 hh时mm分ss秒',false)  // 1969年12月30日 00时52分16秒
+miment().firstDay().format()
+// 2018-04-01 00:00:00
+```
 
-    然后我们把第二个参数设为true
+#### `lastDay`
+`firstDay() => Miment`
 
-        miment().distance(1523408529932).format('YYYY年MM月DD日 hh时mm分ss秒',true)  // 00年01月03日 23时08分23秒
+Get `Miment` object representing last day of the month.
 
+``` js
+miment().lastDay()           // Mon Apr 30 2018 00:00:00 GMT+0800 (CST)
+miment().lastDay().format()  // 2018-04-30 00:00:00
+```
 
-7. `firstDayOfWeek` **获取 本周的第一天(周日)**  不需要参数
+### Computed
 
-          miment().firstDayOfWeek()           // Sun Apr 08 2018 11:27:55 GMT+0800 (CST)
-          miment().firstDayOfWeek().format()  // 2018-04-08 11:27:55
+#### `format`
+`format(formatter: string?, distance: boolean) => string`
 
-    如果想获取周一呢？周二、三、四、五、六呢？
+Format `Miment` into string. Support combination of following formats: "YYYY MM DD hh mm ss SSS ww WW". Pass `distance` flag as `true` if you are formatting results from `distance()`.
 
-          miment().firstDayOfWeek().add(1,'DD').format() // 2018-04-09 11:27:55
+#### `json`
+`json() => Object`
 
-8. `firstDay`  **获取每个月的第一天** 不需要参数
+Get JSON object for date fields.
 
-        miment().firstDay()           // Sun Apr 01 2018 00:00:00 GMT+0800 (CST)
-        miment().firstDay().format()  // 2018-04-01 00:00:00
+``` json
+{
+  "year": 2018,
+  "month": 4,
+  "date": 11,
+  "hour": 8,
+  "minute": 57,
+  "second": 41,
+  "day": 3,
+  "milliSecond": 87
+}
+```
 
-9. `lastDay`  **获取每个月的最后一天** 不需要参数
+#### `stamp`
+`stamp() => number`
 
-        miment().lastDay()           // Mon Apr 30 2018 00:00:00 GMT+0800 (CST)
-        miment().lastDay().format()  // 2018-04-30 00:00:00
+Get timestamp of `Miment` object.
 
-#### 第三类
+### Date API
+All [Date instance APIs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) are inherited. For now it's not recommended to use it since they're unchainable.
 
-10. `Date自带方法` miment继承自Date对象，所以也拥有Date对象的所有方法，这里就不做深入讲解，需要更多关于Date对象的说明，
-请移步至[MDN查看](https://developer.mozilla.org/zh-CN/docs/Web/JavaScript/Reference/Global_Objects/Date)
 
-    > 不过需要注意的是，由于继承而来的方法是属于Date对象的，为了保持一致，我们没有去对方法做改动，所以方法无法返回miment对象，也就是说无法链式调用miment
+## License
+MIT
 
-### 写在最后
-目前这些功能(函数)，是我们团队在日常实践中碰到的比较常用的，如果你对功能有新的需求或者建议，
-欢迎给我们提[Issue](https://github.com/noahlam/Miment/issues),如果喜欢miment，
-请在我的[github](https://github.com/noahlam/Miment)上给我一个star,你的star就是我最大的动力了，谢谢！
+---
+
+Please [star](https://github.com/noahlam/Miment) this repo if you like, and feel free to submit [issues](https://github.com/noahlam/Miment/issues), thanks!

--- a/package.json
+++ b/package.json
@@ -1,7 +1,14 @@
 {
-  "name": "Miment",
+  "name": "miment",
   "version": "0.0.5",
-  "description": "a fast,light weight,simple and non-dependencies datetime library for javascript ( mini moment )",
+  "description": "A fast, light weight, simple and non-dependencies time library for JavaScript (mini moment)",
+  "keywords": [
+    "time",
+    "date",
+    "datetime",
+    "format",
+    "moment"
+  ],
   "files": [
     "./src/miment.js"
   ],


### PR DESCRIPTION
This PR adds English README with largely rewriting on original doc:

* Add API type hints.
* Add simple guide walkthroughs.
* Fix some typos.

Personally I'm stubborn with [whitespace](https://github.com/vinta/pangu.js), hope it's not that bothering😅

For `package.json`, since we are installing with `npm install miment`, so "miment" can be preferred as package name, see also [naming-conventions](https://www.npmjs.com/package/module-best-practices#naming-conventions).
